### PR TITLE
GA Workflow Improve

### DIFF
--- a/.github/workflows/linter-and-tests-checking.yml
+++ b/.github/workflows/linter-and-tests-checking.yml
@@ -9,9 +9,6 @@ on:
 jobs:
   linter-checking:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [12.x]
     steps:
     - uses: actions/checkout@v2
     - name: Cache node modules

--- a/.github/workflows/linter-and-tests-checking.yml
+++ b/.github/workflows/linter-and-tests-checking.yml
@@ -13,11 +13,16 @@ jobs:
       matrix:
         node-version: [12.x]
     steps:
-    - uses: actions/checkout@v1
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+    - uses: actions/checkout@v2
+    - name: Cache node modules
+      uses: actions/cache@v1
       with:
-        node-version: ${{ matrix.node-version }}
+        path: node_modules
+        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.OS }}-build-${{ env.cache-name }}-
+          ${{ runner.OS }}-build-
+          ${{ runner.OS }}-
     - name: install dependencies
       run: npm install
     - name: Run linter


### PR DESCRIPTION
Все раннеры уже по умолчанию имеют ноду, устанавливать её отдельно нет смысла, если вы окей с 12 версией. Плюс добавил кэш, чтобы `npm install` каждый раз с нуля не делать.